### PR TITLE
[chore] Expo plugin support init. 

### DIFF
--- a/expoPlugin/withWechatLib/androidPlugin/index.js
+++ b/expoPlugin/withWechatLib/androidPlugin/index.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.wxapiAndroidManifest = exports.wxapiAndroid = void 0;
+var wxapiAndroid_1 = require("./wxapiAndroid");
+exports.wxapiAndroid = wxapiAndroid_1.default;
+var wxapiAndroidManifest_1 = require("./wxapiAndroidManifest");
+exports.wxapiAndroidManifest = wxapiAndroidManifest_1.default;

--- a/expoPlugin/withWechatLib/androidPlugin/index.ts
+++ b/expoPlugin/withWechatLib/androidPlugin/index.ts
@@ -1,0 +1,4 @@
+import wxapiAndroid from './wxapiAndroid'
+import wxapiAndroidManifest from './wxapiAndroidManifest'
+export { wxapiAndroid, wxapiAndroidManifest }
+

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.js
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.js
@@ -39,14 +39,16 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var config_plugins_1 = require("@expo/config-plugins");
 var fs = require("fs");
 var path = require("path");
-var wxapiAndroid = function (config) {
+var wxapiAndroid = function (config, props) {
+    var androidPackageName = props.androidPackageName;
     return (0, config_plugins_1.withDangerousMod)(config, [
         'android',
         function (config) { return __awaiter(void 0, void 0, void 0, function () {
-            var customePackageName, srcPath, newFileName, newFolderName, newFileContent, newFilePath, newFolderPath, payApiFileName, payApiFileContent, payApiFilePath;
+            var customePackageName, packagePath, srcPath, newFileName, newFolderName, newFileContent, newFilePath, newFolderPath, payApiFileName, payApiFileContent, payApiFilePath;
             return __generator(this, function (_a) {
-                customePackageName = 'com.johome.pro';
-                srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, "app/src/main/java/com/johome/pro");
+                customePackageName = androidPackageName;
+                packagePath = customePackageName.replace(/\./g, '/');
+                srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, "app/src/main/java/".concat(packagePath));
                 newFileName = 'WXEntryActivity.java';
                 newFolderName = 'wxapi';
                 newFileContent = "\npackage ".concat(customePackageName, ".wxapi;\nimport android.app.Activity;\nimport android.content.Intent;\nimport android.os.Bundle;\n\npublic class WXEntryActivity extends Activity {\n  @Override\n  public void onCreate(Bundle savedInstanceState) {\n    super.onCreate(savedInstanceState);\n\n    try {\n      Intent intent = getIntent();\n      Intent intentToBroadcast = new Intent();\n\n      intentToBroadcast.setAction(\"com.hector.nativewechat.ACTION_REDIRECT_INTENT\");\n      intentToBroadcast.putExtra(\"intent\", intent);\n\n      sendBroadcast(intentToBroadcast);\n\n      finish();\n    } catch (Exception e) {\n      e.printStackTrace();\n    }\n  }\n}\n");

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.js
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.js
@@ -1,0 +1,73 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var fs = require("fs");
+var path = require("path");
+var wxapiAndroid = function (config) {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'android',
+        function (config) { return __awaiter(void 0, void 0, void 0, function () {
+            var customePackageName, srcPath, newFileName, newFolderName, newFileContent, newFilePath, newFolderPath, payApiFileName, payApiFileContent, payApiFilePath;
+            return __generator(this, function (_a) {
+                customePackageName = 'com.johome.pro';
+                srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, "app/src/main/java/com/johome/pro");
+                newFileName = 'WXEntryActivity.java';
+                newFolderName = 'wxapi';
+                newFileContent = "\npackage ".concat(customePackageName, ".wxapi;\nimport android.app.Activity;\nimport android.content.Intent;\nimport android.os.Bundle;\n\npublic class WXEntryActivity extends Activity {\n  @Override\n  public void onCreate(Bundle savedInstanceState) {\n    super.onCreate(savedInstanceState);\n\n    try {\n      Intent intent = getIntent();\n      Intent intentToBroadcast = new Intent();\n\n      intentToBroadcast.setAction(\"com.hector.nativewechat.ACTION_REDIRECT_INTENT\");\n      intentToBroadcast.putExtra(\"intent\", intent);\n\n      sendBroadcast(intentToBroadcast);\n\n      finish();\n    } catch (Exception e) {\n      e.printStackTrace();\n    }\n  }\n}\n");
+                newFilePath = path.resolve(srcPath, newFolderName, newFileName);
+                newFolderPath = path.resolve(srcPath, newFolderName);
+                if (!fs.existsSync(newFolderPath)) {
+                    fs.mkdirSync(newFolderPath);
+                }
+                //create a new file
+                if (!fs.existsSync(newFilePath)) {
+                    fs.writeFileSync(newFilePath, newFileContent);
+                }
+                payApiFileName = 'WXPayEntryActivity.java';
+                payApiFileContent = "\n        package ".concat(customePackageName, ".wxapi;\n\n        import android.app.Activity;\n        import android.os.Bundle;\n\n        public class WXPayEntryActivity extends Activity {\n            @Override\n            protected void onCreate(Bundle savedInstanceState) {\n                super.onCreate(savedInstanceState);\n                \n                finish();\n            }\n        }\n        ");
+                payApiFilePath = path.resolve(srcPath, newFolderName, payApiFileName);
+                if (!fs.existsSync(payApiFilePath)) {
+                    fs.writeFileSync(payApiFilePath, payApiFileContent);
+                }
+                return [2 /*return*/, config];
+            });
+        }); },
+    ]);
+};
+exports.default = wxapiAndroid;

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.ts
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.ts
@@ -1,0 +1,83 @@
+import type { ConfigPlugin } from '@expo/config-plugins'
+import { withDangerousMod } from '@expo/config-plugins'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const wxapiAndroid: ConfigPlugin = (config) => {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const customePackageName = 'com.johome.pro'
+      const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, `app/src/main/java/com/johome/pro`)
+      //create a new file
+      const newFileName = 'WXEntryActivity.java'
+      const newFolderName = 'wxapi'
+      const newFileContent = `
+package ${customePackageName}.wxapi;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class WXEntryActivity extends Activity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    try {
+      Intent intent = getIntent();
+      Intent intentToBroadcast = new Intent();
+
+      intentToBroadcast.setAction("com.hector.nativewechat.ACTION_REDIRECT_INTENT");
+      intentToBroadcast.putExtra("intent", intent);
+
+      sendBroadcast(intentToBroadcast);
+
+      finish();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}
+`
+      const newFilePath = path.resolve(srcPath, newFolderName, newFileName)
+
+      //create a new folder
+      const newFolderPath = path.resolve(srcPath, newFolderName)
+      if (!fs.existsSync(newFolderPath)) {
+        fs.mkdirSync(newFolderPath)
+      }
+
+      //create a new file
+      if (!fs.existsSync(newFilePath)) {
+        fs.writeFileSync(newFilePath, newFileContent)
+      }
+
+      //create the pay api file
+      const payApiFileName = 'WXPayEntryActivity.java'
+      const payApiFileContent = `
+        package ${customePackageName}.wxapi;
+
+        import android.app.Activity;
+        import android.os.Bundle;
+
+        public class WXPayEntryActivity extends Activity {
+            @Override
+            protected void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+                
+                finish();
+            }
+        }
+        `
+
+      const payApiFilePath = path.resolve(srcPath, newFolderName, payApiFileName)
+      if (!fs.existsSync(payApiFilePath)) {
+        fs.writeFileSync(payApiFilePath, payApiFileContent)
+      }
+
+      return config
+    },
+  ])
+}
+
+export default wxapiAndroid

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.ts
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroid.ts
@@ -2,13 +2,16 @@ import type { ConfigPlugin } from '@expo/config-plugins'
 import { withDangerousMod } from '@expo/config-plugins'
 import * as fs from 'fs'
 import * as path from 'path'
+import { WechatConfigProps } from '..'
 
-const wxapiAndroid: ConfigPlugin = (config) => {
+const wxapiAndroid: ConfigPlugin<WechatConfigProps> = (config, props) => {
+  const { androidPackageName } = props
   return withDangerousMod(config, [
     'android',
     async (config) => {
-      const customePackageName = 'com.johome.pro'
-      const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, `app/src/main/java/com/johome/pro`)
+      const customePackageName = androidPackageName
+      const packagePath = customePackageName.replace(/\./g, '/')
+      const srcPath = path.resolve(config.modRequest.projectRoot, config.modRequest.platformProjectRoot, `app/src/main/java/${packagePath}`)
       //create a new file
       const newFileName = 'WXEntryActivity.java'
       const newFolderName = 'wxapi'

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroidManifest.js
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroidManifest.js
@@ -1,0 +1,107 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var getMainApplicationOrThrow = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow;
+var wxapiAndroidManifest = function (expoconfig) {
+    return (0, config_plugins_1.withAndroidManifest)(expoconfig, function (manifestConfig) { return __awaiter(void 0, void 0, void 0, function () {
+        var _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    _a = manifestConfig;
+                    return [4 /*yield*/, addCustomActivity(expoconfig, manifestConfig.modResults)
+                        //add new package into queries+ this remove the need to add the package into AndroidManifest.xml
+                    ];
+                case 1:
+                    _a.modResults = _b.sent();
+                    //add new package into queries+ this remove the need to add the package into AndroidManifest.xml
+                    manifestConfig.modResults.manifest['queries'] = __spreadArray(__spreadArray([], manifestConfig.modResults.manifest['queries'], true), [
+                        {
+                            package: [
+                                {
+                                    $: {
+                                        'android:name': 'com.tencent.mm',
+                                    },
+                                },
+                            ],
+                        },
+                    ], false);
+                    return [2 /*return*/, manifestConfig];
+            }
+        });
+    }); });
+};
+function addCustomActivity(config, androidManifest) {
+    return __awaiter(this, void 0, void 0, function () {
+        var mainApplication;
+        return __generator(this, function (_a) {
+            mainApplication = getMainApplicationOrThrow(androidManifest);
+            mainApplication.activity = __spreadArray(__spreadArray([], mainApplication.activity, true), [
+                {
+                    $: {
+                        'android:name': '.wxapi.WXEntryActivity',
+                        'android:exported': 'true',
+                        'android:label': '@string/app_name',
+                        'android:launchMode': 'singleTask',
+                        'android:taskAffinity': 'com.johome.pro',
+                        'android:theme': '@android:style/Theme.Translucent.NoTitleBar',
+                    },
+                },
+                {
+                    $: {
+                        'android:name': '.wxapi.WXPayEntryActivity',
+                        'android:exported': 'true',
+                        'android:label': '@string/app_name',
+                    },
+                },
+            ], false);
+            return [2 /*return*/, androidManifest];
+        });
+    });
+}
+exports.default = wxapiAndroidManifest;

--- a/expoPlugin/withWechatLib/androidPlugin/wxapiAndroidManifest.ts
+++ b/expoPlugin/withWechatLib/androidPlugin/wxapiAndroidManifest.ts
@@ -1,0 +1,56 @@
+import { ExpoConfig } from '@expo/config'
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins'
+
+const { getMainApplicationOrThrow } = AndroidConfig.Manifest
+
+const wxapiAndroidManifest: ConfigPlugin = (expoconfig) => {
+  return withAndroidManifest(expoconfig, async (manifestConfig) => {
+    manifestConfig.modResults = await addCustomActivity(expoconfig, manifestConfig.modResults)
+
+    //add new package into queries+ this remove the need to add the package into AndroidManifest.xml
+    manifestConfig.modResults.manifest['queries'] = [
+      ...manifestConfig.modResults.manifest['queries'],
+      {
+        package: [
+          {
+            $: {
+              'android:name': 'com.tencent.mm',
+            },
+          },
+        ],
+      },
+    ]
+
+    return manifestConfig
+  })
+}
+
+async function addCustomActivity(
+  config: Pick<ExpoConfig, 'android'>,
+  androidManifest: AndroidConfig.Manifest.AndroidManifest
+): Promise<AndroidConfig.Manifest.AndroidManifest> {
+  const mainApplication = getMainApplicationOrThrow(androidManifest)
+  mainApplication.activity = [
+    ...mainApplication.activity,
+    {
+      $: {
+        'android:name': '.wxapi.WXEntryActivity',
+        'android:exported': 'true',
+        'android:label': '@string/app_name',
+        'android:launchMode': 'singleTask',
+        'android:taskAffinity': 'com.johome.pro',
+        'android:theme': '@android:style/Theme.Translucent.NoTitleBar',
+      },
+    },
+    {
+      $: {
+        'android:name': '.wxapi.WXPayEntryActivity',
+        'android:exported': 'true',
+        'android:label': '@string/app_name',
+      },
+    },
+  ]
+  return androidManifest
+}
+
+export default wxapiAndroidManifest

--- a/expoPlugin/withWechatLib/index.js
+++ b/expoPlugin/withWechatLib/index.js
@@ -4,15 +4,16 @@ var config_plugins_1 = require("@expo/config-plugins");
 var androidPlugin_1 = require("./androidPlugin");
 var iosPlugin_1 = require("./iosPlugin");
 //A config plugin for configuring 'native-wechat' for Expo apps.
-var withWechatLib = function (config) {
+var withWechatLib = function (config, props) {
+    var wxAppId = props.wxAppId, iosProjectName = props.iosProjectName, androidPackageName = props.androidPackageName;
     return (0, config_plugins_1.withPlugins)(config, [
         //android plugins
-        androidPlugin_1.wxapiAndroid,
+        [androidPlugin_1.wxapiAndroid, { androidPackageName: androidPackageName }],
         androidPlugin_1.wxapiAndroidManifest,
         //ios plugins TODO: add IOS plugins after making sured that native-wechat is ready for IOS
-        iosPlugin_1.wxapiAppDelegateMm,
-        iosPlugin_1.wxapiAppDelegateH,
-        iosPlugin_1.wxapiInfoPlist,
+        [iosPlugin_1.wxapiAppDelegateMm, { iosProjectName: iosProjectName }],
+        [iosPlugin_1.wxapiAppDelegateH, { iosProjectName: iosProjectName }],
+        [iosPlugin_1.wxapiInfoPlist, { wxAppId: wxAppId }],
     ]);
 };
 exports.default = withWechatLib;

--- a/expoPlugin/withWechatLib/index.js
+++ b/expoPlugin/withWechatLib/index.js
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var androidPlugin_1 = require("./androidPlugin");
+var iosPlugin_1 = require("./iosPlugin");
+//A config plugin for configuring 'native-wechat' for Expo apps.
+var withWechatLib = function (config) {
+    return (0, config_plugins_1.withPlugins)(config, [
+        //android plugins
+        androidPlugin_1.wxapiAndroid,
+        androidPlugin_1.wxapiAndroidManifest,
+        //ios plugins TODO: add IOS plugins after making sured that native-wechat is ready for IOS
+        iosPlugin_1.wxapiAppDelegateMm,
+        iosPlugin_1.wxapiAppDelegateH,
+        iosPlugin_1.wxapiInfoPlist,
+    ]);
+};
+exports.default = withWechatLib;

--- a/expoPlugin/withWechatLib/index.ts
+++ b/expoPlugin/withWechatLib/index.ts
@@ -1,12 +1,23 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins'
 import { wxapiAndroid, wxapiAndroidManifest } from './androidPlugin'
+import { wxapiAppDelegateH, wxapiAppDelegateMm, wxapiInfoPlist } from './iosPlugin'
 
+export interface WechatConfigProps {
+  wxAppId: string
+  iosProjectName: string
+  androidPackageName: string
+}
 //A config plugin for configuring 'native-wechat' for Expo apps.
-const withWechatLib: ConfigPlugin = (config) => {
+const withWechatLib: ConfigPlugin<WechatConfigProps> = (config, props) => {
+  const { wxAppId, iosProjectName, androidPackageName } = props
   return withPlugins(config, [
     //android plugins
-    wxapiAndroid,
+    [wxapiAndroid, { androidPackageName }],
     wxapiAndroidManifest,
+    //ios plugins TODO: add IOS plugins after making sured that native-wechat is ready for IOS
+    [wxapiAppDelegateMm, { iosProjectName }],
+    [wxapiAppDelegateH, { iosProjectName }],
+    [wxapiInfoPlist, { wxAppId }],
   ])
 }
 

--- a/expoPlugin/withWechatLib/index.ts
+++ b/expoPlugin/withWechatLib/index.ts
@@ -1,0 +1,13 @@
+import { ConfigPlugin, withPlugins } from '@expo/config-plugins'
+import { wxapiAndroid, wxapiAndroidManifest } from './androidPlugin'
+
+//A config plugin for configuring 'native-wechat' for Expo apps.
+const withWechatLib: ConfigPlugin = (config) => {
+  return withPlugins(config, [
+    //android plugins
+    wxapiAndroid,
+    wxapiAndroidManifest,
+  ])
+}
+
+export default withWechatLib

--- a/expoPlugin/withWechatLib/iosPlugin/index.js
+++ b/expoPlugin/withWechatLib/iosPlugin/index.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.wxapiInfoPlist = exports.wxapiAppDelegateMm = exports.wxapiAppDelegateH = void 0;
+var wxapiAppDelegateH_1 = require("./wxapiAppDelegateH");
+exports.wxapiAppDelegateH = wxapiAppDelegateH_1.default;
+var wxapiAppDelegateMm_1 = require("./wxapiAppDelegateMm");
+exports.wxapiAppDelegateMm = wxapiAppDelegateMm_1.default;
+var wxapiInfoPlist_1 = require("./wxapiInfoPlist");
+exports.wxapiInfoPlist = wxapiInfoPlist_1.default;

--- a/expoPlugin/withWechatLib/iosPlugin/index.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/index.ts
@@ -1,0 +1,4 @@
+import wxapiAppDelegateH from './wxapiAppDelegateH'
+import wxapiAppDelegateMm from './wxapiAppDelegateMm'
+import wxapiInfoPlist from './wxapiInfoPlist'
+export { wxapiAppDelegateH, wxapiAppDelegateMm, wxapiInfoPlist }

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.js
@@ -1,0 +1,65 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var fs = require("fs");
+var path = require("path");
+var wxapiAppDelegateH = function (config) {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'ios',
+        function (config) { return __awaiter(void 0, void 0, void 0, function () {
+            var fileName, projectName, srcFilePath, data, newData;
+            return __generator(this, function (_a) {
+                fileName = 'AppDelegate.h';
+                projectName = 'JohomePro';
+                srcFilePath = path.resolve(config.modRequest.platformProjectRoot, projectName, fileName);
+                data = fs.readFileSync(srcFilePath, 'utf-8');
+                if (data.includes('#import "WXApi.h"')) {
+                    return [2 /*return*/, config];
+                }
+                newData = data
+                    .replace('#import <UIKit/UIKit.h>', '#import <UIKit/UIKit.h>\n#import "WXApi.h"')
+                    .replace('EXAppDelegateWrapper', 'RCTAppDelegate <UIApplicationDelegate, WXApiDelegate>');
+                //write the file
+                fs.writeFileSync(srcFilePath, newData, 'utf-8');
+                return [2 /*return*/, config];
+            });
+        }); },
+    ]);
+};
+exports.default = wxapiAppDelegateH;

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.js
@@ -39,14 +39,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var config_plugins_1 = require("@expo/config-plugins");
 var fs = require("fs");
 var path = require("path");
-var wxapiAppDelegateH = function (config) {
+var wxapiAppDelegateH = function (config, props) {
+    var iosProjectName = props.iosProjectName;
     return (0, config_plugins_1.withDangerousMod)(config, [
         'ios',
         function (config) { return __awaiter(void 0, void 0, void 0, function () {
             var fileName, projectName, srcFilePath, data, newData;
             return __generator(this, function (_a) {
                 fileName = 'AppDelegate.h';
-                projectName = 'JohomePro';
+                projectName = iosProjectName;
                 srcFilePath = path.resolve(config.modRequest.platformProjectRoot, projectName, fileName);
                 data = fs.readFileSync(srcFilePath, 'utf-8');
                 if (data.includes('#import "WXApi.h"')) {
@@ -54,7 +55,7 @@ var wxapiAppDelegateH = function (config) {
                 }
                 newData = data
                     .replace('#import <UIKit/UIKit.h>', '#import <UIKit/UIKit.h>\n#import "WXApi.h"')
-                    .replace('EXAppDelegateWrapper', 'RCTAppDelegate <UIApplicationDelegate, WXApiDelegate>');
+                    .replace('EXAppDelegateWrapper', 'EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate, WXApiDelegate>');
                 //write the file
                 fs.writeFileSync(srcFilePath, newData, 'utf-8');
                 return [2 /*return*/, config];

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.ts
@@ -1,0 +1,32 @@
+import type { ConfigPlugin } from '@expo/config-plugins'
+import { withDangerousMod } from '@expo/config-plugins'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const wxapiAppDelegateH: ConfigPlugin = (config) => {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      //read the target file
+      const fileName = 'AppDelegate.h'
+      const projectName = 'JohomePro'
+      const srcFilePath = path.resolve(config.modRequest.platformProjectRoot, projectName, fileName)
+
+      //read the file
+      const data = fs.readFileSync(srcFilePath, 'utf-8')
+      if (data.includes('#import "WXApi.h"')) {
+        return config
+      }
+      //modify the file
+      const newData = data
+        .replace('#import <UIKit/UIKit.h>', '#import <UIKit/UIKit.h>\n#import "WXApi.h"')
+        .replace('EXAppDelegateWrapper', 'RCTAppDelegate <UIApplicationDelegate, WXApiDelegate>')
+      //write the file
+      fs.writeFileSync(srcFilePath, newData, 'utf-8')
+
+      return config
+    },
+  ])
+}
+
+export default wxapiAppDelegateH

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateH.ts
@@ -2,14 +2,16 @@ import type { ConfigPlugin } from '@expo/config-plugins'
 import { withDangerousMod } from '@expo/config-plugins'
 import * as fs from 'fs'
 import * as path from 'path'
+import { WechatConfigProps } from '..'
 
-const wxapiAppDelegateH: ConfigPlugin = (config) => {
+const wxapiAppDelegateH: ConfigPlugin<WechatConfigProps> = (config, props) => {
+  const { iosProjectName } = props
   return withDangerousMod(config, [
     'ios',
     async (config) => {
       //read the target file
       const fileName = 'AppDelegate.h'
-      const projectName = 'JohomePro'
+      const projectName = iosProjectName
       const srcFilePath = path.resolve(config.modRequest.platformProjectRoot, projectName, fileName)
 
       //read the file
@@ -20,7 +22,7 @@ const wxapiAppDelegateH: ConfigPlugin = (config) => {
       //modify the file
       const newData = data
         .replace('#import <UIKit/UIKit.h>', '#import <UIKit/UIKit.h>\n#import "WXApi.h"')
-        .replace('EXAppDelegateWrapper', 'RCTAppDelegate <UIApplicationDelegate, WXApiDelegate>')
+        .replace('EXAppDelegateWrapper', 'EXAppDelegateWrapper <UIApplicationDelegate, RCTBridgeDelegate, WXApiDelegate>')
       //write the file
       fs.writeFileSync(srcFilePath, newData, 'utf-8')
 

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var wxapiAppDelegateMm = function (config) {
+    return (0, config_plugins_1.withAppDelegate)(config, function (config) {
+        config.modResults.path = 'ios/JohomePro/AppDelegate.mm';
+        config.modResults = customAppDelegateTransform(config, config.modResults);
+        return config;
+    });
+};
+var customAppDelegateTransform = function (config, appDelegate) {
+    if (appDelegate.contents.includes('// WxApi Config done by JohomePro plugin')) {
+        return appDelegate;
+    }
+    appDelegate.contents = appDelegate.contents
+        .replace('- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {', '- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {\n[WXApi handleOpenURL:url delegate:self];')
+        .replace('return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;', "\n  BOOL wxApiResult = [WXApi handleOpenUniversalLink:userActivity delegate:self];\n  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || wxApiResult || result;\n      ")
+        .replace('@end', "\n- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {\n  return [WXApi handleOpenURL:url delegate:self];\n}\n// WxApi Config done by JohomePro plugin\n\n@end");
+    return appDelegate;
+};
+exports.default = wxapiAppDelegateMm;

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.js
@@ -1,21 +1,22 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var config_plugins_1 = require("@expo/config-plugins");
-var wxapiAppDelegateMm = function (config) {
+var wxapiAppDelegateMm = function (config, props) {
+    var iosProjectName = props.iosProjectName;
     return (0, config_plugins_1.withAppDelegate)(config, function (config) {
-        config.modResults.path = 'ios/JohomePro/AppDelegate.mm';
+        config.modResults.path = "ios/".concat(iosProjectName, "/AppDelegate.mm");
         config.modResults = customAppDelegateTransform(config, config.modResults);
         return config;
     });
 };
 var customAppDelegateTransform = function (config, appDelegate) {
-    if (appDelegate.contents.includes('// WxApi Config done by JohomePro plugin')) {
+    if (appDelegate.contents.includes('// WxApi Config done by expo plugin')) {
         return appDelegate;
     }
     appDelegate.contents = appDelegate.contents
         .replace('- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {', '- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {\n[WXApi handleOpenURL:url delegate:self];')
         .replace('return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;', "\n  BOOL wxApiResult = [WXApi handleOpenUniversalLink:userActivity delegate:self];\n  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || wxApiResult || result;\n      ")
-        .replace('@end', "\n- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {\n  return [WXApi handleOpenURL:url delegate:self];\n}\n// WxApi Config done by JohomePro plugin\n\n@end");
+        .replace('@end', "\n- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {\n  return [WXApi handleOpenURL:url delegate:self];\n}\n// WxApi Config done by expo plugin\n\n@end");
     return appDelegate;
 };
 exports.default = wxapiAppDelegateMm;

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.ts
@@ -1,16 +1,18 @@
 import type { ConfigPlugin } from '@expo/config-plugins'
 import { withAppDelegate } from '@expo/config-plugins'
+import { WechatConfigProps } from '..'
 
-const wxapiAppDelegateMm: ConfigPlugin = (config) => {
+const wxapiAppDelegateMm: ConfigPlugin<WechatConfigProps> = (config, props) => {
+  const { iosProjectName } = props
   return withAppDelegate(config, (config) => {
-    config.modResults.path = 'ios/JohomePro/AppDelegate.mm'
+    config.modResults.path = `ios/${iosProjectName}/AppDelegate.mm`
     config.modResults = customAppDelegateTransform(config, config.modResults)
     return config
   })
 }
 
 const customAppDelegateTransform = (config, appDelegate) => {
-  if (appDelegate.contents.includes('// WxApi Config done by JohomePro plugin')) {
+  if (appDelegate.contents.includes('// WxApi Config done by expo plugin')) {
     return appDelegate
   }
   appDelegate.contents = appDelegate.contents
@@ -31,7 +33,7 @@ const customAppDelegateTransform = (config, appDelegate) => {
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
   return [WXApi handleOpenURL:url delegate:self];
 }
-// WxApi Config done by JohomePro plugin
+// WxApi Config done by expo plugin
 
 @end`
     )

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiAppDelegateMm.ts
@@ -1,0 +1,42 @@
+import type { ConfigPlugin } from '@expo/config-plugins'
+import { withAppDelegate } from '@expo/config-plugins'
+
+const wxapiAppDelegateMm: ConfigPlugin = (config) => {
+  return withAppDelegate(config, (config) => {
+    config.modResults.path = 'ios/JohomePro/AppDelegate.mm'
+    config.modResults = customAppDelegateTransform(config, config.modResults)
+    return config
+  })
+}
+
+const customAppDelegateTransform = (config, appDelegate) => {
+  if (appDelegate.contents.includes('// WxApi Config done by JohomePro plugin')) {
+    return appDelegate
+  }
+  appDelegate.contents = appDelegate.contents
+    .replace(
+      '- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {',
+      '- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {\n[WXApi handleOpenURL:url delegate:self];'
+    )
+    .replace(
+      'return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;',
+      `
+  BOOL wxApiResult = [WXApi handleOpenUniversalLink:userActivity delegate:self];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || wxApiResult || result;
+      `
+    )
+    .replace(
+      '@end',
+      `
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  return [WXApi handleOpenURL:url delegate:self];
+}
+// WxApi Config done by JohomePro plugin
+
+@end`
+    )
+
+  return appDelegate
+}
+
+export default wxapiAppDelegateMm

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
@@ -4,12 +4,6 @@ var config_plugins_1 = require("@expo/config-plugins");
 var wxapiInfoPlist = function (config) {
     return (0, config_plugins_1.withInfoPlist)(config, function (config) {
         // Add or modify entries in the Info.plist as needed
-        config.modResults.CFBundleURLTypes = [
-            {
-                CFBundleURLName: 'weixin',
-                CFBundleURLSchemes: ['wx91390954a8079ed3'], // Replace with your actual WeChat app ID
-            },
-        ];
         config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI'];
         return config;
     });

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var config_plugins_1 = require("@expo/config-plugins");
+var wxapiInfoPlist = function (config) {
+    return (0, config_plugins_1.withInfoPlist)(config, function (config) {
+        // Add or modify entries in the Info.plist as needed
+        config.modResults.CFBundleURLTypes = [
+            {
+                CFBundleURLName: 'weixin',
+                CFBundleURLSchemes: ['wx91390954a8079ed3'], // Replace with your actual WeChat app ID
+            },
+        ];
+        config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI'];
+        return config;
+    });
+};
+exports.default = wxapiInfoPlist;

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.js
@@ -1,9 +1,16 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var config_plugins_1 = require("@expo/config-plugins");
-var wxapiInfoPlist = function (config) {
+var wxapiInfoPlist = function (config, props) {
+    var wxAppId = props.wxAppId;
     return (0, config_plugins_1.withInfoPlist)(config, function (config) {
         // Add or modify entries in the Info.plist as needed
+        config.modResults.CFBundleURLTypes = [
+            {
+                CFBundleURLName: 'weixin',
+                CFBundleURLSchemes: [wxAppId], // Replace with your actual WeChat app ID
+            },
+        ];
         config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI'];
         return config;
     });

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
@@ -1,9 +1,18 @@
 import type { ConfigPlugin } from '@expo/config-plugins'
 import { withInfoPlist } from '@expo/config-plugins'
+import { WechatConfigProps } from '..'
 
-const wxapiInfoPlist: ConfigPlugin = (config) => {
+const wxapiInfoPlist: ConfigPlugin<WechatConfigProps> = (config, props) => {
+  const { wxAppId } = props
   return withInfoPlist(config, (config) => {
     // Add or modify entries in the Info.plist as needed
+    config.modResults.CFBundleURLTypes = [
+      {
+        CFBundleURLName: 'weixin',
+        CFBundleURLSchemes: [wxAppId], // Replace with your actual WeChat app ID
+      },
+    ]
+
     config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI']
 
     return config

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
@@ -1,0 +1,20 @@
+import type { ConfigPlugin } from '@expo/config-plugins'
+import { withInfoPlist } from '@expo/config-plugins'
+
+const wxapiInfoPlist: ConfigPlugin = (config) => {
+  return withInfoPlist(config, (config) => {
+    // Add or modify entries in the Info.plist as needed
+    config.modResults.CFBundleURLTypes = [
+      {
+        CFBundleURLName: 'weixin',
+        CFBundleURLSchemes: ['wx91390954a8079ed3'], // Replace with your actual WeChat app ID
+      },
+    ]
+
+    config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI']
+
+    return config
+  })
+}
+
+export default wxapiInfoPlist

--- a/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
+++ b/expoPlugin/withWechatLib/iosPlugin/wxapiInfoPlist.ts
@@ -4,13 +4,6 @@ import { withInfoPlist } from '@expo/config-plugins'
 const wxapiInfoPlist: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
     // Add or modify entries in the Info.plist as needed
-    config.modResults.CFBundleURLTypes = [
-      {
-        CFBundleURLName: 'weixin',
-        CFBundleURLSchemes: ['wx91390954a8079ed3'], // Replace with your actual WeChat app ID
-      },
-    ]
-
     config.modResults.LSApplicationQueriesSchemes = ['weixin', 'wechat', 'weixinULAPI']
 
     return config

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "types": "dist/src/index.d.ts",
     "scripts": {
         "prepare": "husky install",
-        "build": "tsc && vite build"
+        "build": "tsc && vite build",
+        "plugin-compile-all": "npx tsc ./expoPlugin/*/index.ts --skipLibCheck"
     },
     "files": [
         "src",


### PR DESCRIPTION
其实只需要 所有的.js file 就好了。 expo 的plugin 插入的时候只认js文件 ( 后面确认了的话 ts 文件其实可以全部删掉。)

---
在 expo 项目下 的app.config 里 在plugin 如此添加
``` javascript
  plugins: [
    './plugins/withAndroidNetworkTraffic',
    './plugins/withWechatLib'  // 这是我本地， 如果在包里相应大概的应该是 native-wechat/expoPlugin/withWechatLib
  ],
```
后面如果有需要的话可以看看怎么修改的更完备，然后有什么地方需要修改。

所谓的plugin 其实也就是把配置文档中的所有需要对react 项目内 ios 和android 文件夹下需要修改的地方用expo封装过的方法进行修改。 expo 在用eas 打包的时候会直接把这些修改应用到我们的生成代码里，从而不需要再手动的去进行配置。
