### PR TITLE
fix: isWechatInstalled is not working

### DIFF
--- a/android/src/main/java/com/hector/nativewechat/NativeWechatModuleImpl.java
+++ b/android/src/main/java/com/hector/nativewechat/NativeWechatModuleImpl.java
@@ -129,7 +129,7 @@ public class NativeWechatModuleImpl implements IWXAPIEventHandler {
   }
 
   public void isWechatInstalled(Callback callback) {
-    callback.invoke(!wxApi.isWXAppInstalled());
+    callback.invoke(null, wxApi.isWXAppInstalled());
   }
 
   public void sendAuthRequest(ReadableMap request, Callback callback) {

--- a/ios/RTNWechat/RTNWechat.mm
+++ b/ios/RTNWechat/RTNWechat.mm
@@ -100,8 +100,7 @@ RCT_EXPORT_METHOD(isWechatInstalled:
                   )
 {
     BOOL installed = [WXApi isWXAppInstalled];
-    
-    callback(@[[NSNumber numberWithBool:!installed]]);
+    callback(@[[NSNull null], @(installed)]);
 }
 
 RCT_EXPORT_METHOD(sendAuthRequest:


### PR DESCRIPTION
1. isWechatInstalled函数的逻辑反了
2. 第一个参数指的错误，但测试发现这个参数就是代表是否安装
3. 对于这个函数来说，第一个参数默认就是 null

1. The logic of the isWechatInstalled function is reversed.
2. The first parameter is incorrectly described, but testing revealed that this parameter indeed represents whether WeChat is installed.
3. For this function, the first parameter is null by default.